### PR TITLE
update j4mie/idiorm to version 1.5 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "j4mie/idiorm": "1.4.*"
+        "j4mie/idiorm": "1.5.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I have tested this provider with v1.5 of j4mie/idiorm and run all perfectly. I decided update de version because with v1.4 in silex I cant use array in where clause, because silex thrown a exception.

Example of part of querying:
->where(array(
       'name' => 'Fred',
       'age' => 20
  ))....

Updating the version run perfectly.
